### PR TITLE
consistent TFloat prototypes

### DIFF
--- a/src/arch/dotproductsse.cpp
+++ b/src/arch/dotproductsse.cpp
@@ -39,7 +39,7 @@ TFloat DotProductSSE(const TFloat *u, const TFloat *v, int n) {
   return total;
 }
 #else
-double DotProductSSE(const double *u, const double *v, int n) {
+TFloat DotProductSSE(const TFloat *u, const TFloat *v, int n) {
   int max_offset = n - 2;
   int offset = 0;
   // Accumulate a set of 2 sums in sum, by loading pairs of 2 values from u and

--- a/src/arch/intsimdmatrixsse.cpp
+++ b/src/arch/intsimdmatrixsse.cpp
@@ -73,15 +73,15 @@ static int32_t IntDotProductSSE(const int8_t *u, const int8_t *v, int n) {
 }
 
 // Computes part of matrix.vector v = Wu. Computes 1 result.
-static void PartialMatrixDotVector1(const int8_t *wi, const double *scales, const int8_t *u,
-                                    int num_in, double *v) {
-  double total = IntDotProductSSE(u, wi, num_in);
+static void PartialMatrixDotVector1(const int8_t *wi, const TFloat *scales, const int8_t *u,
+                                    int num_in, TFloat *v) {
+  TFloat total = IntDotProductSSE(u, wi, num_in);
   // Add in the bias and correct for integer values.
   *v = (total + wi[num_in] * INT8_MAX) * *scales;
 }
 
-static void matrixDotVector(int dim1, int dim2, const int8_t *wi, const double *scales,
-                            const int8_t *u, double *v) {
+static void matrixDotVector(int dim1, int dim2, const int8_t *wi, const TFloat *scales,
+                            const int8_t *u, TFloat *v) {
   const int num_out = dim1;
   const int num_in = dim2 - 1;
   int output = 0;


### PR DESCRIPTION
Tfloat patch 1 - TFloat used consistently in prototypes https://github.com/tesseract-ocr/tesseract/pull/3492

Just saw these this morning; anyway: question is: do we want the various specific implementations to have TFloat in their function definition (correctly matching the typedef) or do we want the compiler to match up float <-> TFloat and double <-> TFloat instead?

(if you decide on the latter direction, that would be using the C++ compiler and removing the FAST_TFLOAT #ifdef/#else conditions in the AVX/SSE codes, but it would also mean slightly more work for the compiler, so slightly longer compile times. 🤔 Just thinking out loud and wondering what your preferred coding style for these beasts would be, in the end.)
