### PR TITLE
Looks like  `defined(_OPENMP)` is what's known in the MSVC(2019) world…

### DIFF
--- a/src/arch/dotproduct.cpp
+++ b/src/arch/dotproduct.cpp
@@ -21,7 +21,7 @@ namespace tesseract {
 // Computes and returns the dot product of the two n-vectors u and v.
 TFloat DotProductNative(const TFloat *u, const TFloat *v, int n) {
   TFloat total = 0;
-#if defined(OPENMP_SIMD)
+#if defined(OPENMP_SIMD) || defined(_OPENMP)
 #pragma omp simd reduction(+:total)
 #endif
   for (int k = 0; k < n; k++) {


### PR DESCRIPTION
Don't know if this is useful elsewhere; at least this keeps that important `#pragma opm...` visible to my compiler (MSVC2019 tesseract project). 

What's also mandatory for MSVC to see and act on this #pragma is the compiler option: `/openmp:experimental`. Without it, no joy on this here dev box. 😉   (That's latest MSVC2019; see also blog article from MS: https://devblogs.microsoft.com/cppblog/improved-openmp-support-for-cpp-in-visual-studio/

---

SHA-1: d025c7834b110a72632a8a5992bf4082798c55d6

* Looks like  `defined(_OPENMP)` is what's known in the MSVC(2019) world: added that one as another enabling condition since benchmarks have shown MSVC2019's `/openmp:experimental` to deliver. 😄   (See https://github.com/tesseract-ocr/tesseract/pull/3486#issuecomment-878995893 benchmark reports on @stweil's DotProductNative() implementation)
