### PR TITLE
NEON arch: dead ref cycle fix when neon_available_ is ON

### DIFF
--- a/src/arch/simddetect.cpp
+++ b/src/arch/simddetect.cpp
@@ -258,7 +258,7 @@ SIMDDetect::SIMDDetect() {
 #if defined(HAVE_NEON) || defined(__aarch64__)
   } else if (neon_available_) {
     // NEON detected.
-    SetDotProduct(DotProduct, IntSimdMatrix::intSimdMatrixNEON);
+    SetDotProduct(DotProductNative, IntSimdMatrix::intSimdMatrixNEON);
 #endif
   }
 }
@@ -308,6 +308,12 @@ void SIMDDetect::Update() {
     // SSE selected by config variable.
     SetDotProduct(DotProductSSE, IntSimdMatrix::intSimdMatrixSSE);
     dotproduct_method = "sse";
+#endif
+#if defined(HAVE_NEON) || defined(__aarch64__)
+  } else if (!strcmp(dotproduct.c_str(), "neon") && neon_available_) {
+    // NEON selected by config variable.
+    SetDotProduct(DotProductNative, IntSimdMatrix::intSimdMatrixNEON);
+    dotproduct_method = "neon";
 #endif
   } else if (!strcmp(dotproduct.c_str(), "std::inner_product")) {
     // std::inner_product selected by config variable.


### PR DESCRIPTION
NEON arch: dead ref cycle fix: when neon_available_ is ON, the DotProduct global was set to point to `DotProduct`, which should have been `DotProductNative`, as DotProduct is the *target* global itself: see simddetect.h --> effectively making that part of the SetDotProduct() call identical to this (no-op) statement: `DotProduct = DotProduct;`

Also added the Neon check in the `Update()` API, where it exists together with the other checks (for AVX/SSE/etc.)

----

**Note**: this popped up day before yesterday while I was going through there but had forgotten about this detail until I mixed your work back in. Saw this, then did a quick code review again as I don't have ARM/NEON here, also not as a build target, so this is coded *blind*. I *think* I got it right, though. 🤔 

If not, apologies!