### PR TITLE
small edit: improve GetFirstWords (don't use fixed sized string buffer when not checking overflow)

### DIFF
--- a/src/ccmain/paramsd.cpp
+++ b/src/ccmain/paramsd.cpp
@@ -99,7 +99,7 @@ static void GetFirstWords(const char *s, // source string
                           std::string &d // target string
 ) {
   int full_length = strlen(s);
-  int reqd_len = 0; // No. of chars requird
+  int reqd_len = 0; // No. of chars required
   const char *next_word = s;
 
   while ((n > 0) && reqd_len < full_length) {
@@ -107,10 +107,8 @@ static void GetFirstWords(const char *s, // source string
     next_word = s + reqd_len;
     n--;
   }
-  char t[1024];
-  strncpy(t, s, reqd_len);
-  t[reqd_len] = '\0'; // ensure null terminal
-  d = t;
+  std::string rv(s, reqd_len);  // don't copy beyond s[reqd_len]
+  d = std::move(rv);
 }
 
 // Getter for the name.
@@ -180,7 +178,7 @@ void ParamContent::SetValue(const char *val) {
 }
 
 // Gets the up to the first 3 prefixes from s (split by _).
-// For example, tesseract_foo_bar will be split into tesseract,foo and bar.
+// For example, tesseract_foo_bar will be split into tesseract, foo and bar.
 static void GetPrefixes(const char *s, std::string &level_one, std::string &level_two,
                         std::string &level_three) {
   GetFirstWords(s, 1, level_one);


### PR DESCRIPTION
update STWeil's "Fix function GetFirstWords and modernize function GetPrefixes": GetFirstWords : don't bother with the extra string copy and fixed-sized string buffer which could be attacked by using a 1K+ length word prefix (insane; I know. Anyway)

This also accounts for these commit duplicates: 5943d081e20a87832d575c67b31a3bbd632bcdeb, 47fe923bbb624349eed6155322cf8e828979b81c, 0231ff750e4f146ee8eae9b890b7638401120a8e, c10667d6a83674ec0a8a0d834031211e95a7267e, b04fbb44ebaef0bd811d95bc30ef0e023e796e67, 054dba3e2a61b50d76b693a7d5fa1b45dace72d9

